### PR TITLE
date representation format in DateFieldRenderer class fixed

### DIFF
--- a/src/Admin/Form/Fields/Renderer/DateFieldRenderer.php
+++ b/src/Admin/Form/Fields/Renderer/DateFieldRenderer.php
@@ -20,12 +20,12 @@ class DateFieldRenderer extends InputFieldRenderer
 
         if( !$value )
         {
-            $value = date( 'Y-m-d H:m' );
+            $value = date( 'Y-m-d H:i' );
         }
 
         return Html::input()
             ->setName( $this->field->getNameSpacedName() )
-            ->setValue( date( 'Y-m-d H:m', strtotime( $value ) ) )
+            ->setValue( date( 'Y-m-d H:i', strtotime( $value ) ) )
             ->addClass( 'text datetime-picker' );
     }
 }


### PR DESCRIPTION
`date( 'Y-m-d H:m', strtotime( $value ) )` changed to `date( 'Y-m-d H:i', strtotime( $value ) )` to get hours and minutes instead of hours and months