### PR TITLE
Separate mix file for frontend development

### DIFF
--- a/resources/views/layout/login.blade.php
+++ b/resources/views/layout/login.blade.php
@@ -3,8 +3,8 @@
 <head>
     <title>Arbory</title>
     <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-    <link href="{{ mix('/arbory/css/application.css') }}" media="all" rel="stylesheet"/>
-    <link href="{{ mix('/arbory/css/controllers/sessions.css') }}" media="all" rel="stylesheet"/>
+    <link href="{{ mix('/css/application.css', "arbory") }}" media="all" rel="stylesheet"/>
+    <link href="{{ mix('/css/controllers/sessions.css', "arbory") }}" media="all" rel="stylesheet"/>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
 </head>
 <body class="controller-arbory-sessions view-edit">
@@ -52,6 +52,6 @@
         </form>
     </div>
 </div>
-<script src="{{ mix('/arbory/js/application.js') }}"></script>
+<script src="{{ mix('/js/application.js', "arbory") }}"></script>
 </body>
 </html>

--- a/resources/views/layout/main.blade.php
+++ b/resources/views/layout/main.blade.php
@@ -4,11 +4,11 @@
         <title>Arbory</title>
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-        <link href="{{ mix('/arbory/css/application.css') }}" media="all" rel="stylesheet"/>
-        <link href="{{ mix('/arbory/css/controllers/nodes.css') }}" media="all" rel="stylesheet"/>
+        <link href="{{ mix('/css/application.css', "arbory") }}" media="all" rel="stylesheet"/>
+        <link href="{{ mix('/css/controllers/nodes.css', "arbory") }}" media="all" rel="stylesheet"/>
 
         @foreach($assetsCss as $asset)
-            <link href="{{ mix( $asset ) }}" media="all" rel="stylesheet"/>
+            <link href="{{ mix( $asset, "arbory" ) }}" media="all" rel="stylesheet"/>
         @endforeach
 
         @if($inlineCss)
@@ -29,16 +29,16 @@
 
         <div class="notifications" data-close-text="Close"></div>
 
-        <script src="{{ mix('/arbory/js/application.js') }}"></script>
-        <script src="{{ mix('/arbory/js/controllers/nodes.js') }}"></script>
-        <script src="{{ mix('/arbory/js/admin.js') }}"></script>
+        <script src="{{ mix('/js/application.js', "arbory") }}"></script>
+        <script src="{{ mix('/js/controllers/nodes.js', "arbory") }}"></script>
+        <script src="{{ mix('/js/admin.js', "arbory") }}"></script>
 
         <script async defer
                 src="https://maps.googleapis.com/maps/api/js?key={{ env('GOOGLE_MAPS_API_KEY') }}">
         </script>
 
         @foreach($assetsJs as $asset)
-            <script src="{{ mix( $asset ) }}"></script>
+            <script src="{{ mix( $asset, "arbory" ) }}"></script>
         @endforeach
 
         @if($inlineJs)

--- a/src/Console/Commands/InstallCommand.php
+++ b/src/Console/Commands/InstallCommand.php
@@ -97,6 +97,7 @@ class InstallCommand extends Command
         $this->seedAdminControllers();
         $this->publishFiles();
         $this->publishMixFile();
+        $this->publishFrontMixFile();
         $this->publishConfig();
         $this->runMigrations();
         $this->runSeeder();
@@ -176,6 +177,21 @@ class InstallCommand extends Command
         catch( FileNotFoundException $e )
         {
             $this->error( 'Webpack config not found' );
+        }
+    }
+
+    /**
+     * @return void
+     */
+    protected function publishFrontMixFile()
+    {
+        $webpackConfig = 'webpack.mix.front.js';
+
+        if (!$this->filesystem->exists($webpackConfig))
+        {
+            $content = $this->stubRegistry->make( 'webpack.mix.front.js', [] );
+
+            $this->filesystem->put( base_path( 'webpack.mix.front.js' ), $content );
         }
     }
 
@@ -345,6 +361,6 @@ class InstallCommand extends Command
         shell_exec( 'npm install --silent' );
 
         $this->info( 'Compiling assets' );
-        shell_exec( 'npm run dev' );
+        shell_exec( 'npm run dev -- -- --env.site=admin' );
     }
 }

--- a/stubs/webpack.mix.front.js.stub
+++ b/stubs/webpack.mix.front.js.stub
@@ -1,0 +1,10 @@
+const path = require( "path" );
+
+module.exports = function( mix ) {
+
+    mix
+        .setPublicPath( path.normalize( 'public/front' ) )
+        .sass( 'resources/assets/sass/app.scss', 'css' )
+        .js( 'resources/assets/js/app.js', 'js' );
+};
+

--- a/stubs/webpack.mix.js.stub
+++ b/stubs/webpack.mix.js.stub
@@ -1,5 +1,4 @@
 let mix = require('laravel-mix');
-
 /*
  |--------------------------------------------------------------------------
  | Mix Asset Management
@@ -11,17 +10,6 @@ let mix = require('laravel-mix');
  |
  */
 
-mix.webpackConfig({
-    resolve: {
-        modules: [
-            path.resolve(__dirname, './node_modules'),
-            path.resolve(__dirname, './vendor/arbory/arbory/resources/assets/js/')
-        ]
-    }
-});
 
-mix.js('resources/assets/js/app.js', 'public/js')
-   .js('resources/assets/js/admin.js', 'public/js')
-   .sass('resources/assets/sass/app.scss', 'public/css');
 
 require('./vendor/arbory/arbory/webpack.mix')(mix);

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,62 +1,90 @@
-let fs = require('fs-extra');
+let fs      = require('fs-extra');
+let {env}   = require('minimist')(process.argv.slice(2));
+let path    = require('path');
 
-const controllers = fs.readdirSync('vendor/arbory/arbory/resources/assets/js/controllers');
+if ( env && env.site === "admin" ) {
+    const controllers = fs.readdirSync('vendor/arbory/arbory/resources/assets/js/controllers');
+    module.exports = function (mix) {
 
-module.exports = function (mix) {
+        mix.webpackConfig({
+            resolve: {
+                modules: [
+                    path.resolve(__dirname, './node_modules'),
+                    path.resolve(__dirname, './vendor/arbory/arbory/resources/assets/js/')
+                ]
+            }
+        });
 
-    mix.js(
-        './vendor/arbory/arbory/resources/assets/js/admin.js',
-        'public/arbory/js'
-    );
+        mix.setPublicPath(path.normalize('public/arbory'));
 
-    for (let name of controllers) {
-        mix.js('vendor/arbory/arbory/resources/assets/js/controllers/' + name, 'public/arbory/js/controllers/');
-    }
+        mix.js(
+            'resources/assets/js/admin.js',
+            'public/arbory/js'
+        );
 
-    mix.scripts([
-            './vendor/arbory/arbory/resources/assets/js/environment.js',
-            './vendor/components/jquery/jquery.min.js',
-            './vendor/components/jqueryui/jquery-ui.min.js',
-            './vendor/components/jquery-cookie/jquery.cookie.js',
-            './vendor/ckeditor/ckeditor/ckeditor.js',
-            './vendor/ckeditor/ckeditor/adapters/jquery.js',
-            './vendor/arbory/arbory/resources/assets/js/include/**/*.js',
-        ],
-        'public/arbory/js/application.js'
-    );
 
-    mix.sass(
-        'vendor/arbory/arbory/resources/assets/stylesheets/application.scss',
-        'public/arbory/css/application.css'
-    );
+        mix.js(
+            './vendor/arbory/arbory/resources/assets/js/admin.js',
+            'public/arbory/js'
+        );
 
-    mix.sass(
-        'vendor/arbory/arbory/resources/assets/stylesheets/controllers/nodes.scss',
-        'public/arbory/css/controllers/'
-    );
+        for (let name of controllers) {
+            mix.js('vendor/arbory/arbory/resources/assets/js/controllers/' + name, 'public/arbory/js/controllers/');
+        }
 
-    mix.sass(
-        'vendor/arbory/arbory/resources/assets/stylesheets/controllers/sessions.scss',
-        'public/arbory/css/controllers/'
-    );
+        mix.scripts([
+                './vendor/arbory/arbory/resources/assets/js/environment.js',
+                './vendor/components/jquery/jquery.min.js',
+                './vendor/components/jqueryui/jquery-ui.min.js',
+                './vendor/components/jquery-cookie/jquery.cookie.js',
+                './vendor/ckeditor/ckeditor/ckeditor.js',
+                './vendor/ckeditor/ckeditor/adapters/jquery.js',
+                './vendor/arbory/arbory/resources/assets/js/include/**/*.js',
+            ],
+            'public/arbory/js/application.js'
+        );
 
-    mix.copyDirectory(
-        'vendor/ckeditor/ckeditor/',
-        'public/arbory/ckeditor/'
-    );
+        mix.sass(
+            'vendor/arbory/arbory/resources/assets/stylesheets/application.scss',
+            'public/arbory/css/application.css'
+        );
 
-    mix.copyDirectory(
-        'vendor/arbory/arbory/resources/assets/js/lib/ckeditor/plugins/',
-        'public/arbory/ckeditor/plugins/'
-    );
+        mix.sass(
+            'vendor/arbory/arbory/resources/assets/stylesheets/controllers/nodes.scss',
+            'public/arbory/css/controllers/'
+        );
 
-    mix.copyDirectory(
-        'vendor/arbory/arbory/resources/assets/images/',
-        'public/arbory/images/'
-    );
+        mix.sass(
+            'vendor/arbory/arbory/resources/assets/stylesheets/controllers/sessions.scss',
+            'public/arbory/css/controllers/'
+        );
 
-    mix.copyDirectory(
-        'vendor/unisharp/laravel-filemanager/public/',
-        'public/vendor/laravel-filemanager/'
-    );
-};
+        mix.copyDirectory(
+            'vendor/ckeditor/ckeditor/',
+            'public/arbory/ckeditor/'
+        );
+
+        mix.copyDirectory(
+            'vendor/arbory/arbory/resources/assets/js/lib/ckeditor/plugins/',
+            'public/arbory/ckeditor/plugins/'
+        );
+
+        mix.copyDirectory(
+            'vendor/arbory/arbory/resources/assets/images/',
+            'public/arbory/images/'
+        );
+
+        mix.copyDirectory(
+            'vendor/unisharp/laravel-filemanager/public/',
+            'public/vendor/laravel-filemanager/'
+        );
+    };
+}
+else {
+    module.exports = function(mix) {
+        require(`../../../webpack.mix.front.js`)(mix);
+    };
+}
+
+
+


### PR DESCRIPTION
Issue and discussion here: https://github.com/arbory/arbory/issues/7

I've modified ./webpack.mix.js to simply require arbory's webpack.mix.js, which depending on the value of an env parameter either configures mix to compile admin assets, or skips all that and requires ./webpack.mix.front.js to compile frontend assets.

`arbory:install` is updated to compile admin assets.

webpack.mix.front.js is generated from stub with simple defaults only if it doesn't already exist in root directory. 