### PR TITLE
[googleMaps]: retrieve api key from config

### DIFF
--- a/config/arbory.php
+++ b/config/arbory.php
@@ -70,4 +70,10 @@ return [
             ],
         ],
     ],
+
+    'services' => [
+        'google' => [
+            'maps_api_key' => env('GOOGLE_MAPS_API_KEY')
+        ]
+    ]
 ];

--- a/resources/views/layout/main.blade.php
+++ b/resources/views/layout/main.blade.php
@@ -31,7 +31,7 @@
 
         <div class="notifications" data-close-text="Close"></div>
 
-        <script src="https://maps.googleapis.com/maps/api/js?key={{ env('GOOGLE_MAPS_API_KEY') }}&libraries=places"></script>
+        <script src="https://maps.googleapis.com/maps/api/js?key={{ config('arbory.services.google.maps_api_key') }}&libraries=places"></script>
 
         <script src="{{ mix('/arbory/js/application.js') }}"></script>
         <script src="{{ mix('/arbory/js/controllers/nodes.js') }}"></script>


### PR DESCRIPTION
env() functions usage outside config file is not advised. This may lead to empty env values.

More info: 
[https://laravel.com/docs/5.4/configuration#configuration-caching](url)

> If you execute the config:cache command during your deployment process, you should be sure that you are only calling the env function from within your configuration files.