### PR TITLE
keep file extension if available when getting free filename

### DIFF
--- a/src/Repositories/ArboryFilesRepository.php
+++ b/src/Repositories/ArboryFilesRepository.php
@@ -140,6 +140,11 @@ class ArboryFilesRepository extends AbstractModelsRepository
         {
             $fileNameParts = pathinfo( $fileName );
             $fileName = $fileNameParts['filename'] . '-' . str_random( 10 );
+
+            if (( $extension = array_get( $fileNameParts, 'extension', false ) ))
+            {
+                $fileName .= '.' . $extension;
+            }
         }
 
         return $fileName;


### PR DESCRIPTION
Fixes issue described in https://github.com/arbory/arbory/issues/16