### PR TITLE
Check if 'en' locale already exists.

### DIFF
--- a/database/seeds/ArboryDatabaseSeeder.php
+++ b/database/seeds/ArboryDatabaseSeeder.php
@@ -44,7 +44,7 @@ class ArboryDatabaseSeeder extends Seeder
      */
     protected function seedLocales()
     {
-        if( $this->languageRepository->getModel()->all()->isEmpty() )
+        if( !$this->languageRepository->getModel()->where( [ 'locale' => 'en' ] )->first() )
         {
             $this->languageRepository->create( [
                 'locale' => 'en',


### PR DESCRIPTION
In case when other languages are added with migrations, 'en' language will not be seeded. This commit fixes that by checking explicitly if 'en' exists. 