### PR TITLE
MapCoordinates: allow custom name

### DIFF
--- a/resources/assets/js/Admin/Fields/MapCoordinates.js
+++ b/resources/assets/js/Admin/Fields/MapCoordinates.js
@@ -16,9 +16,10 @@ export default class MapCoordinates {
      */
     registerEventHandlers() {
         let field = this.getField();
+        let name = field.data('data-name');
 
         this.canvas = field.find('.canvas');
-        this.coordinatesInput = field.find('input[data-name=coordinates]');
+        this.coordinatesInput = field.find('input[data-name=\'' + name + '\']');
 
         this.map = new google.maps.Map(this.canvas[0], {
             zoom: field.data('zoom'),


### PR DESCRIPTION
Currently MapCoordinates field is only working using name `coordinates`. This fix allows using custom name.