### PR TITLE
For translatable Setting, resolve its locale at the time of its usage

### DIFF
--- a/src/Admin/Settings/SettingDefinition.php
+++ b/src/Admin/Settings/SettingDefinition.php
@@ -5,6 +5,7 @@ namespace Arbory\Base\Admin\Settings;
 use Arbory\Base\Admin\Form\Fields\ArboryFile;
 use Arbory\Base\Admin\Form\Fields\ArboryImage;
 use Arbory\Base\Admin\Form\Fields\Text;
+use Arbory\Base\Admin\Form\Fields\Translatable;
 
 class SettingDefinition
 {
@@ -167,6 +168,14 @@ class SettingDefinition
     public function isImage(): bool
     {
         return $this->getType() === ArboryImage::class;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTranslatable(): bool
+    {
+        return $this->getType() === Translatable::class;
     }
 
     /**

--- a/src/Admin/Settings/Settings.php
+++ b/src/Admin/Settings/Settings.php
@@ -43,6 +43,11 @@ class Settings
             return $definition->getModel()->file ?? $default;
         }
 
+        if( $definition->isTranslatable() )
+        {
+            return $definition->getModel()->getAttribute( 'value' ) ?? $default;
+        }
+
         return $definition->getValue() ?: $default;
     }
 


### PR DESCRIPTION
At the moment, translatable Setting always uses the locale which was active at the time of calling Arbory\Base\Services\SettingRegistry::importFromDatabase. That creates a problem if locale is changed afterwards.