### PR TITLE
Bugfix of LFM response structure: case of unsuccessful upload

### DIFF
--- a/resources/assets/js/Admin/Fields/RichText.js
+++ b/resources/assets/js/Admin/Fields/RichText.js
@@ -31,9 +31,9 @@ export default class RichText {
             width: '100%',
             height: textarea.outerHeight(),
             filebrowserImageBrowseUrl: '/admin/filemanager?type=Images',
-            filebrowserImageUploadUrl: '/admin/filemanager/upload?type=Images&responseType=json&_token=' + token,
+            filebrowserImageUploadUrl: '/admin/file-manager/upload?type=Images&responseType=json&_token=' + token,
             filebrowserBrowseUrl: '/admin/filemanager?type=Files',
-            filebrowserUploadUrl: '/admin/filemanager/upload?type=Files&responseType=json&_token=' + token
+            filebrowserUploadUrl: '/admin/file-manager/upload?type=Files&responseType=json&_token=' + token
         });
 
         if (!textarea.attr('id')) {

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -36,6 +36,11 @@ Route::group( [ 'middleware' => 'arbory.admin_auth' ], function () {
             'uses' => 'Admin\LanguageController@restore'
         ] );
     } );
+
+    Route::post( 'file-manager/upload', [
+        'as' => 'filemanager.upload',
+        'uses' => 'Admin\UploadController@upload'
+    ] );
 } );
 
 

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -4,34 +4,38 @@ Route::get( '/', [ 'as' => 'login.form', 'uses' => 'Admin\SecurityController@get
 Route::post( 'login', [ 'as' => 'login.attempt', 'uses' => 'Admin\SecurityController@postLogin' ] );
 Route::post( 'logout', [ 'as' => 'logout', 'uses' => 'Admin\SecurityController@postLogout' ] );
 
-Route::group( [ 'middleware' => 'arbory.admin_auth' ], function ()
-{
-    Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\DashboardController::class );
-    Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\UsersController::class );
-    Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\RolesController::class );
-    Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\NodesController::class );
-    Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\TranslationsController::class );
-    Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\SettingsController::class );
-    Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\RedirectsController::class );
-    Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\LanguageController::class );
+Route::group( [ 'middleware' => 'arbory.admin_auth' ], function () {
+    Route::group( [ 'middleware' => 'arbory.admin_module_access' ], function ()
+    {
+        Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\DashboardController::class );
+        Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\UsersController::class );
+        Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\RolesController::class );
+        Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\NodesController::class );
+        Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\TranslationsController::class );
+        Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\SettingsController::class );
+        Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\RedirectsController::class );
+        Admin::modules()->register( \Arbory\Base\Http\Controllers\Admin\LanguageController::class );
 
-    Route::get( 'translations/edit/{namespace}/{group}/{item}', [
-        'as' => 'translations.edit',
-        'uses' => 'Admin\TranslationsController@edit'
-    ] );
+        Route::get( 'translations/edit/{namespace}/{group}/{item}', [
+            'as' => 'translations.edit',
+            'uses' => 'Admin\TranslationsController@edit'
+        ] );
 
-    Route::post( 'translations/update', [
-        'as' => 'translations.update',
-        'uses' => 'Admin\TranslationsController@store'
-    ] );
+        Route::post( 'translations/update', [
+            'as' => 'translations.update',
+            'uses' => 'Admin\TranslationsController@store'
+        ] );
 
-    Route::post( 'language/{language}/disable', [
-        'as' => 'language.disable',
-        'uses' => 'Admin\LanguageController@disable'
-    ] );
+        Route::post( 'language/{language}/disable', [
+            'as' => 'language.disable',
+            'uses' => 'Admin\LanguageController@disable'
+        ] );
 
-    Route::post( 'language/{language}/restore', [
-        'as' => 'language.restore',
-        'uses' => 'Admin\LanguageController@restore'
-    ] );
+        Route::post( 'language/{language}/restore', [
+            'as' => 'language.restore',
+            'uses' => 'Admin\LanguageController@restore'
+        ] );
+    } );
 } );
+
+

--- a/src/Http/Controllers/Admin/UploadController.php
+++ b/src/Http/Controllers/Admin/UploadController.php
@@ -30,8 +30,7 @@ class UploadController extends LfmUploadController
      */
     protected function errorResponse()
     {
-        $responseType = request()->input('responseType');
-        if ($responseType && $responseType == 'json') {
+        if (request('responseType') === 'json') {
             return [
                 "uploaded" => 0,
                 "error" => [

--- a/src/Http/Controllers/Admin/UploadController.php
+++ b/src/Http/Controllers/Admin/UploadController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Arbory\Base\Http\Controllers\Admin;
+
+use UniSharp\LaravelFilemanager\Controllers\UploadController as LfmUploadController;
+
+/**
+ * Class UploadController.
+ */
+class UploadController extends LfmUploadController
+{
+    /**
+     * Upload files
+     *
+     * @param void
+     * @return string
+     */
+    public function upload()
+    {
+        $response = parent::upload();
+
+        return count($this->errors) > 0 ? $this->errorResponse() : $response;
+    }
+
+    /**
+     * Laravel File Manager and CKEditor integration is broken. In cases of unsuccessful uploads,
+     * LFM returns error responses of unexpected format. This fixes that broken behaviour.
+     *
+     * @return array
+     */
+    protected function errorResponse()
+    {
+        $responseType = request()->input('responseType');
+        if ($responseType && $responseType == 'json') {
+            return [
+                "uploaded" => 0,
+                "error" => [
+                    "message" => implode(",\n", $this->errors)
+                ]
+            ];
+        } else {
+            return $this->errors;
+        }
+    }
+}

--- a/src/Providers/ArboryServiceProvider.php
+++ b/src/Providers/ArboryServiceProvider.php
@@ -22,6 +22,7 @@ use Arbory\Base\Http\Middleware\ArboryAdminGuestMiddleware;
 use Arbory\Base\Http\Middleware\ArboryAdminHasAccessMiddleware;
 use Arbory\Base\Http\Middleware\ArboryAdminHasAllowedIpMiddleware;
 use Arbory\Base\Http\Middleware\ArboryAdminInRoleMiddleware;
+use Arbory\Base\Http\Middleware\ArboryAdminModuleAccessMiddleware;
 use Arbory\Base\Http\Middleware\ArboryRouteRedirectMiddleware;
 use Arbory\Base\Menu\Menu;
 use Arbory\Base\Services\AssetPipeline;
@@ -157,6 +158,7 @@ class ArboryServiceProvider extends ServiceProvider
         ] );
 
         $router->aliasMiddleware( 'arbory.admin_auth', ArboryAdminAuthMiddleware::class );
+        $router->aliasMiddleware( 'arbory.admin_module_access', ArboryAdminModuleAccessMiddleware::class );
         $router->aliasMiddleware( 'arbory.admin_quest', ArboryAdminGuestMiddleware::class );
         $router->aliasMiddleware( 'arbory.admin_in_role', ArboryAdminInRoleMiddleware::class );
         $router->aliasMiddleware( 'arbory.admin_has_access', ArboryAdminHasAccessMiddleware::class );


### PR DESCRIPTION
CKEditor expects error response of following structure:
`[
    'uploaded': 0,
    'error': [
        'message': someText
    ] 
]`

But LVM is sending just an array of error messages:
`[msg1, msg2, ...]`

This PR overrides LFM UploadController to correct that behaviour.