### PR TITLE
Fix error after submitting previously cleared ArboryFile file input

### DIFF
--- a/resources/assets/js/Admin/Fields/File.js
+++ b/resources/assets/js/Admin/Fields/File.js
@@ -14,6 +14,10 @@ export default class File {
     registerEventHandlers() {
         let field = this.getField();
 
+        field.find('input').on('change', function () {
+            field.find('input.remove').val(0);
+        });
+
         field.find('button.remove').on('click', function () {
             field.find('input.remove').val(1);
             field.find('.thumbnail').hide();

--- a/src/Admin/Form/Fields/Renderer/IconPickerRenderer.php
+++ b/src/Admin/Form/Fields/Renderer/IconPickerRenderer.php
@@ -68,7 +68,17 @@ class IconPickerRenderer extends SelectFieldRenderer
             return Html::div()->addClass( 'element' );
         }
 
-        $content = $iconNode->path->asXML();
+        $node = simplexml_load_string($iconNode->asXML());
+        $path = array_first($node->xpath('/symbol//path[@d]'));
+
+        if( $path )
+        {
+            $content = $path->asXML();
+        }
+        else 
+        {
+            return Html::div()->addClass( 'element' );
+        }
 
         $attributes = $iconNode->attributes();
         $width = (int) $attributes->width;

--- a/src/Admin/Form/Fields/SpriteIcon.php
+++ b/src/Admin/Form/Fields/SpriteIcon.php
@@ -14,6 +14,11 @@ class SpriteIcon extends Select
     protected $spritePath;
 
     /**
+     * @var string
+     */
+    protected $filter;
+
+    /**
      * @param string $name
      */
     public function __construct( $name )
@@ -30,6 +35,16 @@ class SpriteIcon extends Select
     public function sprite( string $path ): self
     {
         $this->spritePath = $path;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function filter( string $filter )
+    {
+        $this->filter = $filter;
 
         return $this;
     }
@@ -102,6 +117,11 @@ class SpriteIcon extends Select
                 {
                     $id = (string) $attributeValue;
                 }
+            }
+
+            if( $this->filter && !str_contains($id, $this->filter) )
+            {
+                continue;
             }
 
             if( $id )


### PR DESCRIPTION
Fixes error where a resource.content.file.remove=1 parameter is needlessly submitted. Error occurs in the following scenario:

1. A file is added and successfully submitted to an ArboryFile form field input.
2. File input is cleared (using X button) without submitting the form or reloading the page.
3. A new file is added to the file input.
4. Form is submitted.