### PR TITLE
Fix error after submitting previously cleared ArboryFile file input 

### DIFF
--- a/resources/assets/js/Admin/Fields/File.js
+++ b/resources/assets/js/Admin/Fields/File.js
@@ -14,6 +14,10 @@ export default class File {
     registerEventHandlers() {
         let field = this.getField();
 
+        field.find('input').on('change', function () {
+            field.find('input.remove').val(0);
+        });
+
         field.find('button.remove').on('click', function () {
             field.find('input.remove').val(1);
             field.find('.thumbnail').hide();


### PR DESCRIPTION
Fixes error where a resource.content.file.remove=1 parameter is needlessly submitted. Error occurs in the following scenario:

1. A file is added and successfully submitted to an ArboryFile form field input.
2. File input is cleared (using X button) without submitting the form or reloading the page.
3. A new file is added to the file input.
4. Form is submitted.
