### PR TITLE
Add AdminModuleAccess middeware to all admin routes

### DIFF
--- a/src/Providers/ArboryServiceProvider.php
+++ b/src/Providers/ArboryServiceProvider.php
@@ -198,7 +198,7 @@ class ArboryServiceProvider extends ServiceProvider
 
         $this->app['router']->group( [
             'as' => 'admin.',
-            'middleware' => [ 'admin', 'arbory.admin_auth' ],
+            'middleware' => [ 'admin', 'arbory.admin_auth', 'arbory.admin_module_access' ],
             'namespace' => '',
             'prefix' => config( 'arbory.uri' )
         ],function () use ($adminRoutes)


### PR DESCRIPTION
When Role don't have permission for custom module, it is removed from menu, but is still accessible unless Middleware is added. 