### PR TITLE
fix incorrect query condition for active nodes

### DIFF
--- a/src/Repositories/NodesRepository.php
+++ b/src/Repositories/NodesRepository.php
@@ -32,7 +32,7 @@ class NodesRepository extends AbstractModelsRepository
 
         if( $this->isQueryingOnlyActiveNodes() )
         {
-            $query->where( 'active', true );
+            $query->active();
         }
 
         return $query;


### PR DESCRIPTION
Fixes exception caused by an invalid column being queried when using NodesRepository to fetch active nodes. 

Should have been updated to use the active scope together with https://github.com/arbory/arbory/pull/99