### PR TITLE
Fix node preview slug hash mismatch

### DIFF
--- a/config/arbory.php
+++ b/config/arbory.php
@@ -105,7 +105,7 @@ return [
     ],
 
     'preview' => [
-        'enabled' => env('ARBORY_PREVIEW_ENABLED', false),
+        'enabled' => true,
         'slug_salt' => env('APP_KEY')
     ]
 ];

--- a/config/arbory.php
+++ b/config/arbory.php
@@ -106,6 +106,6 @@ return [
 
     'preview' => [
         'enabled' => env('ARBORY_PREVIEW_ENABLED', false),
-        'slug_salt' => env('ARBORY_PREVIEW_SLUG_SALT')
+        'slug_salt' => env('APP_KEY')
     ]
 ];

--- a/config/arbory.php
+++ b/config/arbory.php
@@ -102,5 +102,9 @@ return [
         'google' => [
             'maps_api_key' => env('GOOGLE_MAPS_API_KEY')
         ]
+    ],
+
+    'preview' => [
+        'slug_salt' => env('ARBORY_PREVIEW_SLUG_SALT')
     ]
 ];

--- a/config/arbory.php
+++ b/config/arbory.php
@@ -105,6 +105,7 @@ return [
     ],
 
     'preview' => [
+        'enabled' => env('ARBORY_PREVIEW_ENABLED', false),
         'slug_salt' => env('ARBORY_PREVIEW_SLUG_SALT')
     ]
 ];

--- a/src/Admin/Form/Fields/Slug.php
+++ b/src/Admin/Form/Fields/Slug.php
@@ -63,12 +63,14 @@ class Slug extends AbstractField
             ->iconOnly()
             ->render();
 
-        return Html::div([
+        $content = Html::div([
             Html::div($label)->addClass('label-wrap'),
             Html::div([$input, $button])->addClass('value'),
             $this->getLinkElement(),
-            $this->getPreviewLinkElement(),
+            $this->getPreviewLinkElement()
         ])->addClass('field type-slug')->addAttributes(['data-name' => 'slug']);
+
+        return $content;
     }
 
     /**
@@ -147,7 +149,7 @@ class Slug extends AbstractField
             $urlToSlug .= '/';
         }
 
-        $slugHashed = 'preview-' . sha1('__cms-preview' . '/' . $urlToSlug . $this->getValue());
+        $slugHashed = 'preview-' . sha1(config('arbory.preview.slug_salt') . '/' . $urlToSlug . $this->getValue());
 
         return url($slugHashed);
     }

--- a/src/Admin/Form/Fields/Slug.php
+++ b/src/Admin/Form/Fields/Slug.php
@@ -67,8 +67,11 @@ class Slug extends AbstractField
             Html::div($label)->addClass('label-wrap'),
             Html::div([$input, $button])->addClass('value'),
             $this->getLinkElement(),
-            $this->getPreviewLinkElement()
         ])->addClass('field type-slug')->addAttributes(['data-name' => 'slug']);
+
+        if (config('arbory.preview.enabled')) {
+            $content->append($this->getPreviewLinkElement());
+        }
 
         return $content;
     }

--- a/src/Nodes/ContentTypeRoutesRegister.php
+++ b/src/Nodes/ContentTypeRoutesRegister.php
@@ -121,7 +121,7 @@ class ContentTypeRoutesRegister
             $slug = $base . '/' . $item->getSlug();
 
             if (! $item->active) {
-                $this->registerNodeRoutes($item, 'preview-' . sha1('cms-preview' . $slug));
+                $this->registerNodeRoutes($item, 'preview-' . sha1(config('arbory.preview.slug_salt') . $slug));
                 if ($item->children->count()) {
                     $this->registerPreviewRoutesForNodeCollection($item->children, $slug);
                 }
@@ -145,7 +145,7 @@ class ContentTypeRoutesRegister
         foreach ($items as $item) {
             $slug = $base . '/' . $item->getSlug();
 
-            $this->registerNodeRoutes($item, 'preview-' . sha1('cms-preview' . $slug));
+            $this->registerNodeRoutes($item, 'preview-' . sha1(config('arbory.preview.slug_salt') . $slug));
 
             if ($item->children->count()) {
                 $this->registerPreviewRoutesForNodeCollection($item->children, $slug);

--- a/src/Nodes/ContentTypeRoutesRegister.php
+++ b/src/Nodes/ContentTypeRoutesRegister.php
@@ -120,10 +120,9 @@ class ContentTypeRoutesRegister
         foreach ($items as $item) {
             $slug = $base . '/' . $item->getSlug();
 
-            if (! $item->active && config('arbory.preview.enabled')) {
-                $this->registerNodeRoutes($item, 'preview-' . sha1(config('arbory.preview.slug_salt') . $slug));
-                if ($item->children->count()) {
-                    $this->registerPreviewRoutesForNodeCollection($item->children, $slug);
+            if (! $item->active) {
+                if (config('arbory.preview.enabled')) {
+                    $this->registerPreviewRoutes($item, $slug);
                 }
                 continue;
             }
@@ -133,6 +132,19 @@ class ContentTypeRoutesRegister
             if ($item->children->count()) {
                 $this->registerRoutesForNodeCollection($item->children, $slug);
             }
+        }
+    }
+
+    /**
+     * @param Node $item
+     * @param string $slug
+     */
+    protected function registerPreviewRoutes(Node $item, $slug)
+    {
+        $this->registerNodeRoutes($item, 'preview-' . sha1(config('arbory.preview.slug_salt') . $slug));
+
+        if ($item->children->count()) {
+            $this->registerPreviewRoutesForNodeCollection($item->children, $slug);
         }
     }
 

--- a/src/Nodes/ContentTypeRoutesRegister.php
+++ b/src/Nodes/ContentTypeRoutesRegister.php
@@ -120,7 +120,7 @@ class ContentTypeRoutesRegister
         foreach ($items as $item) {
             $slug = $base . '/' . $item->getSlug();
 
-            if (! $item->active) {
+            if (! $item->active && config('arbory.preview.enabled')) {
                 $this->registerNodeRoutes($item, 'preview-' . sha1(config('arbory.preview.slug_salt') . $slug));
                 if ($item->children->count()) {
                     $this->registerPreviewRoutesForNodeCollection($item->children, $slug);


### PR DESCRIPTION
Fixes issue caused by a typo where hashed slug generated in admin Slug is different from the one registered in ContentTypeRoutesRegister. Gets salt value from config instead.

Additionally, adds config value to enable/disable preview functionality globally to avoid potential issue where pages could be previewed without configuring salt.