### PR TITLE
Add id and for attributes to checkboxes and labels in associated set

### DIFF
--- a/src/Admin/Form/Fields/Renderer/AssociatedSetRenderer.php
+++ b/src/Admin/Form/Fields/Renderer/AssociatedSetRenderer.php
@@ -3,6 +3,7 @@
 namespace Arbory\Base\Admin\Form\Fields\Renderer;
 
 use Arbory\Base\Admin\Form\Controls\CheckboxControl;
+use Arbory\Base\Admin\Form\Fields\Checkbox;
 use Arbory\Base\Admin\Form\Fields\ControlFieldInterface;
 use Arbory\Base\Admin\Form\Fields\FieldInterface;
 use Arbory\Base\Admin\Form\Fields\Renderer\Styles\Options\StyleOptionsInterface;
@@ -66,30 +67,35 @@ class AssociatedSetRenderer extends ControlFieldRenderer
      *
      * @return Element
      */
-    protected function getAssociatedItem( $name, $value, $label )
+    protected function getAssociatedItem($name, $value, $label)
     {
-        $checkbox = new CheckboxControl();
-
         $inputName = Element::formatName($name);
+        $field = new Checkbox($inputName);
 
+        $field->setFieldSet($this->getField()->getFieldSet());
+        /** @var CheckboxControl $checkbox */
+        $checkbox = $field->getRenderer()->getControl();
 
         $checkbox->setName($inputName);
         $checkbox->setValue($value);
+        $checkbox->addAttributes([
+            'id' => $field->getFieldId()
+        ]);
 
-        if ( $this->field instanceof ControlFieldInterface ) {
-            $checkbox->setReadOnly(! $this->field->isInteractive());
+        if ($this->field instanceof ControlFieldInterface) {
+            $checkbox->setReadOnly(!$this->field->isInteractive());
             $checkbox->setDisabled($this->field->isDisabled());
         }
 
-        if ( in_array($value, $this->values, true) ) {
+        if (in_array($value, $this->values, true)) {
             $checkbox->setChecked(true);
         }
 
         return Html::div([
             $checkbox->render($checkbox->element()),
-            Html::label($label)->addAttributes([ 'for' => $this->field->getFieldId() ]),
+            Html::label($label)->addAttributes(['for' => $field->getFieldId()]),
         ])
-                   ->addClass('type-associated-set-item');
+            ->addClass('type-associated-set-item');
     }
 
     /**


### PR DESCRIPTION
Fixes bug where clicking on labels within an associated items list (BelongsToMany field) doesn't toggle the related checkbox. 