### PR TITLE
Remove type check when comparing submitted with existing ids

### DIFF
--- a/src/Admin/Form/Fields/BelongsToMany.php
+++ b/src/Admin/Form/Fields/BelongsToMany.php
@@ -74,7 +74,7 @@ class BelongsToMany extends AbstractField
 
         foreach( $submittedIds as $id )
         {
-            if( !in_array( $id, $existingIds, true ) )
+            if( !in_array( $id, $existingIds ) )
             {
                 $relation->attach( $id );
             }


### PR DESCRIPTION
Fixes bug where pivot table holding relations data would be updated with new duplicate entries on each save when using BelongsToMany field. 

Without the fix, existing ids with a int type are being strictly compared to submitted ids with a string type, causing the `!in_array` check to always evaluate as true.