### PR TITLE
Use correct field and value for active checkbox in users controller

### DIFF
--- a/src/Http/Controllers/Admin/UsersController.php
+++ b/src/Http/Controllers/Admin/UsersController.php
@@ -50,7 +50,10 @@ class UsersController extends Controller
             $fields->text('last_name');
             $fields->text('email')->rules('required|unique:admin_users,email,' . $user->getKey());
             $fields->password('password')->rules('min:6|' . ($user->exists ? 'nullable' : 'required'));
-            $fields->boolean('active')->setValue($this->getActivations()->completed($user));
+            $checkbox = $fields->checkbox('active');
+            if ($this->getActivations()->completed($user)) {
+                $checkbox->setAttributes(['checked']);
+            }
             $fields->belongsToMany('roles');
         });
 


### PR DESCRIPTION
Implements the following fixes:

- Uses Checkbox field instead of Boolean which has been dropped as of https://github.com/arbory/arbory/pull/107
- Uses the correct way (as of https://github.com/arbory/arbory/pull/107) of prechecking a Checkbox when it is not based on a model property value