### PR TITLE
Extend Deactivator from Checkbox field

### DIFF
--- a/src/Admin/Form/Fields/Deactivator.php
+++ b/src/Admin/Form/Fields/Deactivator.php
@@ -10,7 +10,7 @@ use Arbory\Base\Admin\Form\Fields\Renderer\CheckBoxFieldRenderer;
  * Class DateTime
  * @package Arbory\Base\Admin\Form\Fields
  */
-class Deactivator extends ControlField
+class Deactivator extends Checkbox
 {
     protected $activateAtName = 'activate_at';
     protected $expireAtName = 'expire_at';


### PR DESCRIPTION
Extend Deactivator field from Checkbox field because it basically is a checkbox with specific logic added on top.

Fixes an error caused by getCheckedValue method not being found when Deactivator field is being rendered by CheckBoxFieldRenderer.