### PR TITLE
Add missing return statement to fulfill interface

### DIFF
--- a/src/Admin/Form/Fields/Renderer/Styles/Options/StyleOptions.php
+++ b/src/Admin/Form/Fields/Renderer/Styles/Options/StyleOptions.php
@@ -48,6 +48,8 @@ class StyleOptions implements StyleOptionsInterface
         $this->additional = new Fluent(
             array_merge($this->additional->getAttributes(), $data)
         );
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Fixes the following error caused by a missing return statement.

```
Return value of Arbory\Base\Admin\Form\Fields\Renderer\Styles\Options\StyleOptions::addAdditional() must implement interface Arbory\Base\Admin\Form\Fields\Renderer\Styles\Options\StyleOptionsInterface, none returned
```