### PR TITLE
Added support for overridable grid URLs

### DIFF
--- a/src/Admin/Grid.php
+++ b/src/Admin/Grid.php
@@ -64,7 +64,7 @@ class Grid
      * @var Filter
      */
     protected $filter;
-    
+
     /**
      * @var callable
      */
@@ -369,11 +369,11 @@ class Grid
      */
     public function getOpenUrl(Model $model): ?string
     {
-        if($customUrlOpener = $this->getOpenUrlCallback()) {
+        if ($customUrlOpener = $this->getOpenUrlCallback()) {
             return call_user_func($customUrlOpener, $model);
         }
 
-        if($this->hasTool('create')) {
+        if ($this->hasTool('create')) {
             return $this->getModule()->url('edit', [$model->getKey()]);
         }
 

--- a/src/Admin/Grid.php
+++ b/src/Admin/Grid.php
@@ -68,7 +68,7 @@ class Grid
     /**
      * @var callable
      */
-    protected $openUrlCallback;
+    protected $rowUrlCallback;
 
     /**
      * @param Model $model
@@ -367,9 +367,9 @@ class Grid
      *
      * @return string|null
      */
-    public function getOpenUrl(Model $model): ?string
+    public function getRowUrl(Model $model): ?string
     {
-        if ($customUrlOpener = $this->getOpenUrlCallback()) {
+        if ($customUrlOpener = $this->getRowUrlCallback()) {
             return call_user_func($customUrlOpener, $model);
         }
 
@@ -383,19 +383,19 @@ class Grid
     /**
      * @return callable
      */
-    public function getOpenUrlCallback(): callable
+    public function getRowUrlCallback(): callable
     {
-        return $this->openUrlCallback;
+        return $this->rowUrlCallback;
     }
 
     /**
-     * @param callable $openUrlCallback
+     * @param callable $rowUrlCallback
      *
      * @return Grid
      */
-    public function setOpenUrlCallback(callable $openUrlCallback): self
+    public function setRowUrlCallback(callable $rowUrlCallback): self
     {
-        $this->openUrlCallback = $openUrlCallback;
+        $this->rowUrlCallback = $rowUrlCallback;
 
         return $this;
     }

--- a/src/Admin/Grid.php
+++ b/src/Admin/Grid.php
@@ -64,6 +64,11 @@ class Grid
      * @var Filter
      */
     protected $filter;
+    
+    /**
+     * @var callable
+     */
+    protected $openUrlCallback;
 
     /**
      * @param Model $model
@@ -355,6 +360,44 @@ class Grid
     public function hasTool(string $tool): bool
     {
         return in_array($tool, $this->enabledDefaultTools, false);
+    }
+
+    /**
+     * @param Model $model
+     *
+     * @return string|null
+     */
+    public function getOpenUrl(Model $model): ?string
+    {
+        if($customUrlOpener = $this->getOpenUrlCallback()) {
+            return call_user_func($customUrlOpener, $model);
+        }
+
+        if($this->hasTool('create')) {
+            return $this->getModule()->url('edit', [$model->getKey()]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return callable
+     */
+    public function getOpenUrlCallback(): callable
+    {
+        return $this->openUrlCallback;
+    }
+
+    /**
+     * @param callable $openUrlCallback
+     *
+     * @return Grid
+     */
+    public function setOpenUrlCallback(callable $openUrlCallback): self
+    {
+        $this->openUrlCallback = $openUrlCallback;
+
+        return $this;
     }
 
     /**

--- a/src/Admin/Grid/Column.php
+++ b/src/Admin/Grid/Column.php
@@ -289,7 +289,7 @@ class Column
         if ($this->displayer === null) {
             $value = (string) $value;
 
-            if ($url = $this->grid->getOpenUrl($model)) {
+            if ($url = $this->grid->getRowUrl($model)) {
                 return Html::link($value)->addAttributes([
                     'href' => $url,
                 ]);

--- a/src/Admin/Grid/Column.php
+++ b/src/Admin/Grid/Column.php
@@ -289,9 +289,9 @@ class Column
         if ($this->displayer === null) {
             $value = (string) $value;
 
-            if ($this->grid->hasTool('create')) {
+            if ($url = $this->grid->getOpenUrl($model)) {
                 return Html::link($value)->addAttributes([
-                    'href' => $this->grid->getModule()->url('edit', [$model->getKey()]),
+                    'href' => $url,
                 ]);
             }
 


### PR DESCRIPTION
Allows to change the default grid click url to anything
```
$grid->setRowUrlCallback(function(Model $model) {
    return 'new url';

   return null; // Empty values will not make the cell clickable
});
```