### PR TITLE
Fix migration bug for settings table

### DIFF
--- a/database/migrations/2017_06_07_113300_modify_primary_key_in_settings_table.php
+++ b/database/migrations/2017_06_07_113300_modify_primary_key_in_settings_table.php
@@ -17,6 +17,7 @@ class ModifyPrimaryKeyInSettingsTable extends Migration
 
         Schema::table('settings', function (Blueprint $table) {
             $table->dropColumn('id');
+            $table->dropUnique('settings_name_unique');
             $table->string('name')->primary()->change();
         });
     }


### PR DESCRIPTION
Fix issue with settings table migration where on latest MariaDB version (10.4) it would cause an access violation error with incorrect index name when changing unique index to primary.