### PR TITLE
Fix issue when adding new constructor block to constructor node

### DIFF
--- a/src/Admin/Constructor/Models/ConstructorBlock.php
+++ b/src/Admin/Constructor/Models/ConstructorBlock.php
@@ -3,6 +3,7 @@
 namespace Arbory\Base\Admin\Constructor\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class ConstructorBlock extends Model
 {
@@ -21,18 +22,17 @@ class ConstructorBlock extends Model
         'position',
     ];
 
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
-     */
-    public function owner()
+    public function owner(): MorphTo
     {
         return $this->morphTo();
     }
 
-    /**
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
-     */
-    public function content()
+    public function block(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function content(): MorphTo
     {
         return $this->morphTo();
     }

--- a/stubs/pages.stub
+++ b/stubs/pages.stub
@@ -2,10 +2,11 @@
 
 use Arbory\Base\Admin\Constructor\ConstructorLayout;
 use Arbory\Base\Admin\Constructor\Models\ConstructorPage;
+use Arbory\Base\Admin\Form\FieldSet;
 use Arbory\Base\Pages\TextPage;
 
 Page::register( TextPage::class )
-    ->fields( function( Arbory\Base\Admin\Form\FieldSet $fieldSet )
+    ->fields( function( FieldSet $fieldSet )
     {
         $fieldSet->richtext('html');
     } )


### PR DESCRIPTION
**Expected:** You can open the page after saving
**Actual:** Error is returned 
`Call to undefined relationship [block] on model [Arbory\Base\Admin\Constructor\Models\ConstructorBlock]. `

This fixed above mentioned issue.