### PR TITLE
Add readability to constructor 

### DIFF
--- a/src/Admin/Form/Fields/Renderer/ConstructorFieldRenderer.php
+++ b/src/Admin/Form/Fields/Renderer/ConstructorFieldRenderer.php
@@ -88,7 +88,7 @@ class ConstructorFieldRenderer implements RendererInterface
             $fieldSet = $this->field->getRelationFieldSet($this->field->buildFromBlock($object), '_template_');
 
             $select->append(
-                Html::option($object->name())->setValue($type)->addAttributes(
+                Html::option($object->title())->setValue($type)->addAttributes(
                     [
                         'data-template' => $this->getRelationItemHtml($object, $fieldSet, '_template_'),
                     ]


### PR DESCRIPTION
When adding new constructor fields, users are given an option to choose between basically either class names of the block or some snake_cased values (depending on how You implement it). 

This takes use of BlockInterface title() method in order to display something readable :) 