### PR TITLE
Allow multiple paths for SVG icons

### DIFF
--- a/src/Admin/Form/Fields/Renderer/IconPickerRenderer.php
+++ b/src/Admin/Form/Fields/Renderer/IconPickerRenderer.php
@@ -63,13 +63,13 @@ class IconPickerRenderer extends SelectFieldRenderer
 
         $node = simplexml_load_string($iconNode->asXML());
         $paths = $node->xpath('/symbol//path[@d]');
-        
+
         if (! $paths) {
-            return Html::div()->addClass( 'element' );
+            return Html::div()->addClass('element');
         }
-        
+
         $content = '';
-        
+
         foreach ($paths as $path) {
             $content .= $path->asXML();
         }

--- a/src/Admin/Form/Fields/Renderer/IconPickerRenderer.php
+++ b/src/Admin/Form/Fields/Renderer/IconPickerRenderer.php
@@ -62,12 +62,16 @@ class IconPickerRenderer extends SelectFieldRenderer
         }
 
         $node = simplexml_load_string($iconNode->asXML());
-        $path = array_first($node->xpath('/symbol//path[@d]'));
-
-        if ($path) {
-            $content = $path->asXML();
-        } else {
-            return Html::div()->addClass('element');
+        $paths = $node->xpath('/symbol//path[@d]');
+        
+        if (! $paths) {
+            return Html::div()->addClass( 'element' );
+        }
+        
+        $content = '';
+        
+        foreach ($paths as $path) {
+            $content .= $path->asXML();
         }
 
         $attributes = $iconNode->attributes();


### PR DESCRIPTION
Right now IconPicker ignores all paths after the first one. This is an unnecessary limit and doesn't work for complex SVGs.