### PR TITLE
Improve active node check and display speed for controller view

### DIFF
--- a/resources/assets/stylesheets/layout/nodes.scss
+++ b/resources/assets/stylesheets/layout/nodes.scss
@@ -95,6 +95,11 @@
                 color: $color-text-normal;
             }
 
+            &:not(.active) + ul .trigger
+            {
+                color: $color-text-lightest;
+            }
+
             span
             {
                 margin-left: 0;

--- a/src/Nodes/Admin/Grid/Renderer.php
+++ b/src/Nodes/Admin/Grid/Renderer.php
@@ -116,7 +116,7 @@ class Renderer implements Renderable
                 $li->append($collapser);
             }
 
-            $cell = Html::div()->addClass('node-cell ' . ($item->isDirectlyActive() ? 'active' : ''));
+            $cell = Html::div()->addClass('node-cell ' . ($item->isPublic() ? 'active' : ''));
 
             $link = str_replace('__ID__', $item->getKey(), $url);
 

--- a/src/Nodes/Admin/Grid/Renderer.php
+++ b/src/Nodes/Admin/Grid/Renderer.php
@@ -116,7 +116,7 @@ class Renderer implements Renderable
                 $li->append($collapser);
             }
 
-            $cell = Html::div()->addClass('node-cell '.($item->isActive() ? 'active' : ''));
+            $cell = Html::div()->addClass('node-cell ' . ($item->isDirectlyActive() ? 'active' : ''));
 
             $link = str_replace('__ID__', $item->getKey(), $url);
 

--- a/src/Nodes/Node.php
+++ b/src/Nodes/Node.php
@@ -180,7 +180,7 @@ class Node extends Model
      */
     public function isDirectlyActive()
     {
-        return $this->hasActivated() && !$this->hasExpired();
+        return $this->hasActivated() && ! $this->hasExpired();
     }
 
     /**

--- a/src/Nodes/Node.php
+++ b/src/Nodes/Node.php
@@ -176,6 +176,14 @@ class Node extends Model
     }
 
     /**
+     * @return bool
+     */
+    public function isDirectlyActive()
+    {
+        return $this->hasActivated() && !$this->hasExpired();
+    }
+
+    /**
      * Return parent id (legacy support).
      *
      * @return mixed

--- a/src/Nodes/Node.php
+++ b/src/Nodes/Node.php
@@ -164,7 +164,7 @@ class Node extends Model
      */
     public function getActiveAttribute()
     {
-        if (! $this->hasActivated() || $this->hasExpired()) {
+        if (! $this->isPublic()) {
             return false;
         }
 
@@ -178,7 +178,7 @@ class Node extends Model
     /**
      * @return bool
      */
-    public function isDirectlyActive()
+    public function isPublic()
     {
         return $this->hasActivated() && ! $this->hasExpired();
     }


### PR DESCRIPTION
Opening node grid with too many nodes the page in unusable because every single node is checking if their parent nodes are active. Improve speed by only checking the node itself and use css to achieve the same styling as previously.