### PR TITLE
Fix sortable ui logic for constructor fields

### DIFF
--- a/resources/assets/js/Admin/Fields/Sortable.js
+++ b/resources/assets/js/Admin/Fields/Sortable.js
@@ -72,7 +72,7 @@ export default class Sortable {
     setLocationInput(item, locationIndex) {
         // Expects that the position input is always a direct descendant of the fieldset.item entry
         let sortByName = this.getSortByName();
-        let positionInput = item.find(`> input[data-name="${sortByName}"]`).first();
+        let positionInput = item.find(`input[data-name="${sortByName}"]`).first();
 
         if(positionInput.length) {
             positionInput.val(locationIndex);


### PR DESCRIPTION
Removes unnecessarily strict `>` from selector for finding position input in sortable fields. Calling `first()` on results should already return the closest descendant. 

The change is needed to fix sortable behaviour for fields rendered via `ConstructorLayout`, or other custom layouts where it's not easily possible to render the hidden position input as a direct descendant of the field's container.