### PR TITLE
Apply orderBy from field in constructor layout

### DIFF
--- a/src/Admin/Constructor/ConstructorLayout.php
+++ b/src/Admin/Constructor/ConstructorLayout.php
@@ -50,16 +50,23 @@ class ConstructorLayout extends AbstractLayout implements FormLayoutInterface
     public function __construct($name = 'blocks')
     {
         $this->name = $name;
-
         $this->fieldConfigurator = function () {
             $this->field->setItemRenderer(new Form\Fields\Renderer\Nested\PaneledItemRenderer);
             $this->field->addClass('in-layout');
-            $this->field->sortable();
+            $this->field->sortable($this->getFieldOrderBy());
 
             $this->field->setHidden(true);
             $this->field->setLabel('');
             $this->field->setAllowToAdd(false);
         };
+    }
+
+    /**
+     * @return string
+     */
+    protected function getFieldOrderBy(): string
+    {
+        return $this->field->getOrderBy() ?? 'position';
     }
 
     /**


### PR DESCRIPTION
Adds support for using non-default column for ordering constructor blocks. Currently, `setOrderBy() / sortable()` calls on constructor field are not fully respected in `ConstructorLayout`.