### PR TITLE
Fix error on save in Redirects module

### DIFF
--- a/src/Http/Controllers/Admin/RedirectsController.php
+++ b/src/Http/Controllers/Admin/RedirectsController.php
@@ -35,6 +35,7 @@ class RedirectsController extends Controller
                 ->setLabel(trans('arbory::redirect.to_url'));
 
             $fieldSet->add(new Select('status'))
+                ->rules('required')
                 ->options($this->getStatusOptions())
                 ->setLabel(trans('arbory::redirect.status.name'));
         });


### PR DESCRIPTION
Currently, there are no validation rules set for status field, but submitting the form without selecting status throws an error:
```
SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'status' cannot be null (SQL: insert into `redirects` (`from_url`, `to_url`, `status`, `updated_at`, `created_at`) values (example.test, example.test, ?, 2021-01-09 23:25:32, 2021-01-09 23:25:32))
```
Fix adds required rule to status field.