### PR TITLE
Fix new user create error

### DIFF
--- a/src/Http/Controllers/Admin/UsersController.php
+++ b/src/Http/Controllers/Admin/UsersController.php
@@ -6,6 +6,8 @@ use Arbory\Base\Html\Html;
 use Arbory\Base\Admin\Form;
 use Arbory\Base\Admin\Grid;
 use Arbory\Base\Admin\Admin;
+use Cartalyst\Sentinel\Activations\ActivationRepositoryInterface;
+use Cartalyst\Sentinel\Users\EloquentUser;
 use Illuminate\Http\Request;
 use Arbory\Base\Auth\Users\User;
 use Illuminate\Routing\Controller;
@@ -50,7 +52,7 @@ class UsersController extends Controller
             $fields->text('last_name');
             $fields->text('email')->rules('required|unique:admin_users,email,'.$user->getKey());
             $fields->password('password')->rules('min:6|'.($user->exists ? 'nullable' : 'required'));
-            $fields->checkbox('active')->setValue($this->getActivations()->completed($user));
+            $fields->checkbox('active')->setValue($this->isActivated($user));
             $fields->belongsToMany('roles');
         });
 
@@ -127,10 +129,19 @@ class UsersController extends Controller
     }
 
     /**
-     * @return \Cartalyst\Sentinel\Activations\ActivationRepositoryInterface
+     * @return ActivationRepositoryInterface
      */
     protected function getActivations()
     {
         return $this->admin->sentinel()->getActivationRepository();
+    }
+
+    /**
+     * @param EloquentUser $user
+     * @return bool
+     */
+    protected function isActivated(EloquentUser $user): bool
+    {
+        return $user->exists && $this->getActivations()->completed($user);
     }
 }


### PR DESCRIPTION
It's impossible to create a new admin user, because an error is thrown in `UsersController` form, caused by passing unsaved User model to a method which calls `$user->getUserId()`. User model implements `Cartalyst\Sentinel\Users\UserInterface`, which expects `$user->getUserId()` to return int.

```
Return value of Cartalyst\Sentinel\Users\EloquentUser::getUserId() must be of the type int, null returned
```
Fix checks if User exists first.