### PR TITLE
Fix support for 5.6 and 5.8 laravel versions in ArboryFileFactory

### DIFF
--- a/src/Files/ArboryFileFactory.php
+++ b/src/Files/ArboryFileFactory.php
@@ -40,7 +40,16 @@ class ArboryFileFactory
             throw new \InvalidArgumentException('Unsupported relation');
         }
 
-        $localKey = explode('.', $relation->getQualifiedForeignKey())[1];
+        // ensure support for both laravel versions 5.6 and 5.8
+        // method name for laravel 5.6
+        $methodName = 'getQualifiedForeignKey';
+        if (method_exists($relation, 'getQualifiedForeignKeyName'))
+        {
+            // method name for laravel 5.8
+            $methodName = 'getQualifiedForeignKeyName';
+        }
+
+        $localKey = explode('.', $relation->{$methodName}())[1];
 
         $model->setAttribute($localKey, $arboryFile->getKey());
         $model->setRelation($relationName, $arboryFile);


### PR DESCRIPTION
There is a method name change in Laravel versions (both supported by Arbory 1.0 version) in Illuminate\Database\Eloquent\Relations\BelongsTo class, namely, method getQualifiedForeignKey name is changed to getQualifiedForeignKeyName. Since Arbory 1.0 version uses former method name in ArboryFileFactory class, this fix ensures compatibility for both these Laravel versions.